### PR TITLE
improve types and add jest.config

### DIFF
--- a/.jestconfig.json
+++ b/.jestconfig.json
@@ -1,6 +1,0 @@
-{
-  "testPathIgnorePatterns": [
-    "/node_modules/",
-    "/dist/"
-  ]
-}

--- a/config/jest.config.js
+++ b/config/jest.config.js
@@ -1,4 +1,3 @@
-const fs = require('fs');
 const path = require('path');
 
 module.exports = {

--- a/config/jest.config.js
+++ b/config/jest.config.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+const path = require('path');
+
+module.exports = {
+  rootDir: process.cwd(),
+  coverageDirectory: '<rootDir>/.coverage',
+  globals: {
+    __DEV__: true
+  },
+  collectCoverageFrom: [
+    'src/**/*.{js,jsx,ts,tsx}',
+    '!src/**/*.d.ts',
+    '!src/**/*.test.*',
+    '!src/test/**/*.*'
+  ],
+  setupFilesAfterEnv: [path.join(__dirname, './setupTests.ts')],
+  testMatch: [
+    '<rootDir>/src/**/__tests__/**/*.ts?(x)',
+    '<rootDir>/src/**/?(*.)(spec|test).ts?(x)'
+  ],
+  testEnvironment: 'node',
+  testURL: 'http://localhost',
+  transform: {
+    '^.+\\.(ts|tsx)$': 'ts-jest'
+  },
+  transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$'],
+  moduleNameMapper: {
+    '^react-native$': 'react-native-web'
+  },
+  moduleFileExtensions: ['web.js', 'js', 'json', 'web.jsx', 'jsx', 'ts', 'tsx', 'feature', 'csv']
+}

--- a/config/setupTests.ts
+++ b/config/setupTests.ts
@@ -1,0 +1,21 @@
+import { GlobalWithFetchMock } from "jest-fetch-mock";
+
+const customGlobal: GlobalWithFetchMock = global as GlobalWithFetchMock;
+customGlobal.fetch = require('jest-fetch-mock');
+customGlobal.fetchMock = customGlobal.fetch;
+
+// this is just a little hack to silence a warning that we'll get until react
+// fixes this: https://github.com/facebook/react/pull/14853
+const originalError = console.error
+beforeAll(() => {
+  console.error = (...args: any[]) => {
+    if (/Warning.*not wrapped in act/.test(args[0])) {
+      return
+    }
+    originalError.call(console, ...args)
+  }
+})
+
+afterAll(() => {
+  console.error = originalError
+})

--- a/package.json
+++ b/package.json
@@ -83,8 +83,6 @@
     "use-graphql"
   ],
   "dependencies": {
-    "react": "^16.8.6",
-    "react-dom": "^16.8.6",
     "use-ssr": "^1.0.18"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,12 +13,14 @@
     "react-dom": "^16.8.6"
   },
   "devDependencies": {
+    "@testing-library/react": "^8.0.1",
     "@types/fetch-mock": "^7.2.3",
     "@types/jest": "^24.0.12",
+    "@types/node": "^12.0.10",
     "@types/react": "^16.8.19",
     "@types/react-dom": "^16.8.4",
-    "fetch-mock": "^7.3.1",
     "jest": "^24.7.1",
+    "jest-fetch-mock": "^2.1.2",
     "react-hooks-testing-library": "^0.6.0",
     "ts-jest": "^24.0.0",
     "typescript": "^3.4.5"
@@ -26,7 +28,8 @@
   "scripts": {
     "prepublish": "yarn build # runs before publish",
     "build": "rm -rf dist && ./node_modules/.bin/tsc --module CommonJS",
-    "test": "tsc -p . --noEmit && tsc -p ./src/__tests__ && jest",
+    "test": "tsc -p . --noEmit && tsc -p ./src/__tests__ && jest -c ./config/jest.config.js --env=jsdom",
+    "test:watch": "jest -c ./config/jest.config.js --env=jsdom --watch",
     "clean": "npm prune; yarn cache clean; rm -rf ./node_modules package-lock.json yarn.lock; yarn"
   },
   "files": [
@@ -80,6 +83,8 @@
     "use-graphql"
   ],
   "dependencies": {
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6",
     "use-ssr": "^1.0.18"
   }
 }

--- a/src/__tests__/tsconfig.json
+++ b/src/__tests__/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "noEmit": true
+    "noEmit": true,
+    "noUnusedLocals": false
   },
   "include": [
     "./**/*.ts",

--- a/src/__tests__/tsconfig.json
+++ b/src/__tests__/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "noEmit": true,
-    "noUnusedLocals": false
+    "noEmit": true
   },
   "include": [
     "./**/*.ts",

--- a/src/__tests__/useFetch.test.tsx
+++ b/src/__tests__/useFetch.test.tsx
@@ -1,21 +1,107 @@
-// import React from "react";
-// import ReactDOM from "react-dom";
-// import useFetch from '../index';
-// console.log('USE FETCH: ', useFetch)
+import React from "react";
+import {
+  useFetch,
+  useGet,
+  useDelete,
+  usePost,
+  usePut,
+  usePatch,
+  useQuery,
+  useMutation
+} from '../index';
+import ReactDOM from 'react-dom';
+import {
+  render,
+  cleanup,
+  waitForElement
+} from '@testing-library/react'
 
-// const TestApp = () => {
-//   var [data, loading, error, request] = useFetch('https://example.com', { onMount: true });
-//   return (<div>{loading}</div>);
-// };
+import {FetchMock} from "jest-fetch-mock";
 
-describe('useFetch', () => {
+const fetch = global.fetch as FetchMock;
+
+import { act } from "react-dom/test-utils"
+
+interface Person {
+  name: string;
+  age: number;
+}
+
+const TestApp = () => {
+  const { loading, data, error } = useFetch<Person>('https://example.com', { onMount: true });
+
+  return (
+    <>
+      {loading && <div data-testid="loading">loading...</div>}
+      {error && <div data-testid="error">{error.message}</div>}
+      {data && 
+        <div>
+          <div data-testid="person-name">{data.name}</div>
+          <div data-testid="person-age">{data.age}</div>
+        </div>
+      }
+    </>
+  );
+};
+
+describe('use-http', () => {
   it('should be defined/exist when imported', () => {
-    expect(() => {}).toBeDefined();
+    expect(typeof useFetch).toBe("function");
   });
 
-  // it('can be used without crashing', () => {
+  it('should define useGet', () => {
+    expect(typeof useGet).toBe("function");
+  });
+
+  it('should define usePost', () => {
+    expect(typeof usePost).toBe("function");
+  });
+
+  it('should define usePut', () => {
+    expect(typeof usePut).toBe("function");
+  });
+
+  it('should define useDelete', () => {
+    expect(typeof useDelete).toBe("function");
+  });
+
+  it('should define usePatch', () => {
+    expect(typeof usePatch).toBe("function");
+  });
+
+  it('should define useQuery', () => {
+    expect(typeof useQuery).toBe("function");
+  });
+
+  it('should define useMutation', () => {
+    expect(typeof useMutation).toBe("function");
+  });
+
+  // it('can be used without crashing', async () => {
   //   const div = document.createElement("div");
-  //   ReactDOM.render(<TestApp />, div);
-  //   ReactDOM.unmountComponentAtNode(div);
+    
+  //   act(() => {
+  //     ReactDOM.render(<TestApp />, div);
+  //   });
   // });
+
+  describe("useFetch", () => {
+    afterEach(() => {
+      fetch.resetMocks();
+    });
+
+    it('should execute GET command', async () => {
+      fetch.mockResponseOnce(JSON.stringify({
+        name: "Joe Bloggs",
+        age: 48
+      }));
+      
+      const { getAllByTestId } = render(<TestApp/>)
+
+      const els = await waitForElement(() => getAllByTestId(/^person-/));
+
+      expect(els[0].innerHTML).toBe("Joe Bloggs");
+      expect(els[1].innerHTML).toBe("48");
+    })
+  });
 });

--- a/src/__tests__/useFetch.test.tsx
+++ b/src/__tests__/useFetch.test.tsx
@@ -87,6 +87,7 @@ describe('use-http', () => {
 
   describe("useFetch", () => {
     afterEach(() => {
+      cleanup();
       fetch.resetMocks();
     });
 

--- a/src/__tests__/useFetch.test.tsx
+++ b/src/__tests__/useFetch.test.tsx
@@ -77,13 +77,13 @@ describe('use-http', () => {
     expect(typeof useMutation).toBe("function");
   });
 
-  // it('can be used without crashing', async () => {
-  //   const div = document.createElement("div");
+  it('can be used without crashing', async () => {
+    const div = document.createElement("div");
     
-  //   act(() => {
-  //     ReactDOM.render(<TestApp />, div);
-  //   });
-  // });
+    act(() => {
+      ReactDOM.render(<TestApp />, div);
+    });
+  });
 
   describe("useFetch", () => {
     afterEach(() => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,9 @@
+export enum HTTPMethod {
+  DELETE = 'DELETE',
+  GET = 'GET',
+  HEAD = 'HEAD',
+  OTIONS = 'OPTIONS',
+  PATCH = 'PATCH',
+  POST = 'POST',
+  PUT = 'PUT',
+}

--- a/src/useDelete.ts
+++ b/src/useDelete.ts
@@ -1,9 +1,10 @@
 import useFetch, { Options } from './useFetch'
+import { HTTPMethod } from "./types";
 
-export const useDelete = (url: string, options?: Options) => {
-  const { data, loading, error, del } = useFetch(url, {
-    method: 'DELETE',
+export const useDelete = <TData = any>(url: string, options?: Options) => {
+  const { data, loading, error, del } = useFetch<TData>(url, {
+    method: HTTPMethod.DELETE,
     ...options
   })
-  return Object.assign([ data, loading, error, del ], { data, loading, error, del, delete: del })
+  return Object.assign([data, loading, error, del], { data, loading, error, del, delete: del })
 }

--- a/src/useFetch.ts
+++ b/src/useFetch.ts
@@ -121,7 +121,7 @@ export function useFetch<TData = any>(arg1: useFetchArg1, arg2?: Options | Reque
         if (err.name !== 'AbortError') setError(err)
       } finally {
         controller.current = null
-        //setLoading(false)
+        setLoading(false)
       }
     },
     [url]

--- a/src/useFetch.ts
+++ b/src/useFetch.ts
@@ -1,7 +1,6 @@
 import { useEffect, useState, useCallback, useRef, useContext, useMemo } from 'react'
 import URLContext from './URLContext'
 import { HTTPMethod } from "./types";
-import { any } from "prop-types";
 
 const isObject = (obj: any) => Object.prototype.toString.call(obj) === '[object Object]'
 

--- a/src/useGet.ts
+++ b/src/useGet.ts
@@ -1,9 +1,10 @@
 import useFetch, { Options } from './useFetch'
+import { HTTPMethod } from "./types";
 
-export const useGet = (url: string, options?: Options) => {
-  const { data, loading, error, get } = useFetch(url, {
-    method: 'GET',
+export const useGet = <TData = any>(url: string, options?: Options) => {
+  const { data, loading, error, get } = useFetch<TData>(url, {
+    method: HTTPMethod.GET,
     ...options
   })
-  return Object.assign([ data, loading, error, get ], { data, loading, error, get })
+  return Object.assign([data, loading, error, get], { data, loading, error, get })
 }

--- a/src/useMutation.ts
+++ b/src/useMutation.ts
@@ -2,7 +2,7 @@ import useFetch, { URLContext } from '.'
 import { useContext, useCallback } from 'react';
 
 
-export const useMutation = (arg1: string, arg2: string) => {
+export const useMutation = <TData = any>(arg1: string, arg2: string) => {
   const context = useContext(URLContext)
 
   let url = arg1
@@ -13,7 +13,7 @@ export const useMutation = (arg1: string, arg2: string) => {
     MUTATION = arg1
   }
 
-  const request = useFetch(url)
+  const request = useFetch<TData>(url)
 
   const mutate = useCallback(inputs => request.mutate(MUTATION, inputs), [])
 

--- a/src/usePatch.ts
+++ b/src/usePatch.ts
@@ -1,9 +1,10 @@
 import useFetch, { Options } from './useFetch'
+import { HTTPMethod } from "./types";
 
-export const usePatch = (url: string, options?: Options) => {
-  const { data, loading, error, patch } = useFetch(url, {
-    method: 'PATCH',
+export const usePatch = <TData = any>(url: string, options?: Options) => {
+  const { data, loading, error, patch } = useFetch<TData>(url, {
+    method: HTTPMethod.PATCH,
     ...options
   })
-  return Object.assign([ data, loading, error, patch ], { data, loading, error, patch })
+  return Object.assign([data, loading, error, patch], { data, loading, error, patch })
 }

--- a/src/usePost.ts
+++ b/src/usePost.ts
@@ -1,9 +1,10 @@
 import useFetch, { Options } from './useFetch'
+import { HTTPMethod } from "./types";
 
-export const usePost = (url: string, options?: Options) => {
-  const { data, loading, error, post } = useFetch(url, {
-    method: 'POST',
+export const usePost = <TData = any>(url: string, options?: Options) => {
+  const { data, loading, error, post } = useFetch<TData>(url, {
+    method: HTTPMethod.POST,
     ...options
   })
-  return Object.assign([ data, loading, error, post ], { data, loading, error, post })
+  return Object.assign([data, loading, error, post], { data, loading, error, post })
 }

--- a/src/usePut.ts
+++ b/src/usePut.ts
@@ -1,9 +1,10 @@
 import useFetch, { Options } from './useFetch'
+import { HTTPMethod } from "./types";
 
-export const usePut = (url: string, options?: Options) => {
-  const { data, loading, error, put } = useFetch(url, {
-    method: 'PUT',
+export const usePut = <TData = any>(url: string, options?: Options) => {
+  const { data, loading, error, put } = useFetch<TData>(url, {
+    method: HTTPMethod.PUT,
     ...options
   })
-  return Object.assign([ data, loading, error, put ], { data, loading, error, put })
+  return Object.assign([data, loading, error, put], { data, loading, error, put })
 }

--- a/src/useQuery.ts
+++ b/src/useQuery.ts
@@ -2,7 +2,7 @@ import useFetch, { URLContext } from '.'
 import { useContext, useCallback } from 'react';
 
 
-export const useQuery = (arg1: string, arg2: string) => {
+export const useQuery = <TData = any>(arg1: string, arg2: string) => {
   const context = useContext(URLContext)
 
   let url = arg1
@@ -13,7 +13,7 @@ export const useQuery = (arg1: string, arg2: string) => {
     QUERY = arg1
   }
 
-  const request = useFetch(url)
+  const request = useFetch<TData>(url)
 
   const query = useCallback(inputs => request.query(QUERY, inputs), [])
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,22 @@
 {
   "compilerOptions": {
+    "declaration": true,
+    "esModuleInterop": true,
+    "jsx": "react",
+    "lib": [
+      "es5",
+      "es2015",
+      "es2016",
+      "dom",
+      "esnext"
+    ],
     "module": "es2015",
     "moduleResolution": "node",
-    "target": "es6",
-    "strict": true,
+    "noImplicitAny": true,
     "outDir": "dist",
-    "declaration": true,
     "sourceMap": true,
-    "jsx": "react",
-    "esModuleInterop": true
+    "strict": true,
+    "target": "es6"
   },
   "include": [
     "src/*.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "module": "es2015",
     "moduleResolution": "node",
     "noImplicitAny": true,
+    "noUnusedLocals": true,
     "outDir": "dist",
     "sourceMap": true,
     "strict": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -98,7 +98,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/runtime@^7.4.2":
+"@babel/runtime@^7.4.2", "@babel/runtime@^7.4.5":
   version "7.4.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.4.5.tgz#582bb531f5f9dc67d2fcb682979894f75e253f12"
   integrity sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==
@@ -292,12 +292,36 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^12.0.9"
 
+"@sheerun/mutationobserver-shim@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz#8013f2af54a2b7d735f71560ff360d3a8176a87b"
+  integrity sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q==
+
+"@testing-library/dom@^5.0.0":
+  version "5.2.1"
+  resolved "https://registry.npmjs.org/@testing-library/dom/-/dom-5.2.1.tgz#3f2af5229af106c0ccd5078bcb820958310604bc"
+  integrity sha512-K30UE+UKwyI/iTaQsSJXVYBPnPsTLlcNT1QEhHKKqlsehu7SzWTSkCE3xW0qvMPIkPb3/rVisDx7Viez/qmAKA==
+  dependencies:
+    "@babel/runtime" "^7.4.5"
+    "@sheerun/mutationobserver-shim" "^0.3.2"
+    aria-query "3.0.0"
+    pretty-format "^24.8.0"
+    wait-for-expect "^1.2.0"
+
 "@testing-library/react-hooks@~1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-1.0.2.tgz#85a91e6c63015cc861f42713f9066bf62f491457"
   integrity sha512-YBSeOC3diWm1DQUjj1Nixj8Y1O3GA6gZaQo3QrmRxslUF8utN0ywZOY7rWbbFdgoSJUdWb6LWU8LwIN+/egujg==
   dependencies:
     "@babel/runtime" "^7.4.2"
+
+"@testing-library/react@^8.0.1":
+  version "8.0.1"
+  resolved "https://registry.npmjs.org/@testing-library/react/-/react-8.0.1.tgz#91c254adf855b13de50020613cb5d3915f9f7875"
+  integrity sha512-N/1pJfhEnNYkGyxuw4xbp03evaS0z/CT8o0QgTfJqGlukAcU15xf9uU1w03NHKZJcU69nOCBAoAkXHtHzYwMbg==
+  dependencies:
+    "@babel/runtime" "^7.4.5"
+    "@testing-library/dom" "^5.0.0"
 
 "@types/babel__core@^7.1.0":
   version "7.1.2"
@@ -368,6 +392,11 @@
   integrity sha512-MU1HIvWUme74stAoc3mgAi+aMlgKOudgEvQDIm1v4RkrDudBh1T+NFp5sftpBAdXdx1J0PbdpJ+M2EsSOi1djA==
   dependencies:
     "@types/jest-diff" "*"
+
+"@types/node@^12.0.10":
+  version "12.0.10"
+  resolved "https://registry.npmjs.org/@types/node/-/node-12.0.10.tgz#51babf9c7deadd5343620055fc8aff7995c8b031"
+  integrity sha512-LcsGbPomWsad6wmMNv7nBLw7YYYyfdYcz6xryKYQhx89c3XXan+8Q6AJ43G5XDIaklaVkK3mE4fCb0SBvMiPSQ==
 
 "@types/prop-types@*":
   version "15.7.1"
@@ -490,6 +519,14 @@ are-we-there-yet@~1.1.2:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
 
+aria-query@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/aria-query/-/aria-query-3.0.0.tgz#65b3fcc1ca1155a8c9ae64d6eee297f15d5133cc"
+  integrity sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=
+  dependencies:
+    ast-types-flow "0.0.7"
+    commander "^2.11.0"
+
 arr-diff@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
@@ -531,6 +568,11 @@ assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
+
+ast-types-flow@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
+  integrity sha1-9wtzXGvKGlycItmCw+Oef+ujva0=
 
 astral-regex@^1.0.0:
   version "1.0.0"
@@ -591,15 +633,6 @@ babel-plugin-jest-hoist@^24.6.0:
   dependencies:
     "@types/babel__traverse" "^7.0.6"
 
-babel-polyfill@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
-  integrity sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=
-  dependencies:
-    babel-runtime "^6.26.0"
-    core-js "^2.5.0"
-    regenerator-runtime "^0.10.5"
-
 babel-preset-jest@^24.6.0:
   version "24.6.0"
   resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-24.6.0.tgz#66f06136eefce87797539c0d63f1769cc3915984"
@@ -607,14 +640,6 @@ babel-preset-jest@^24.6.0:
   dependencies:
     "@babel/plugin-syntax-object-rest-spread" "^7.0.0"
     babel-plugin-jest-hoist "^24.6.0"
-
-babel-runtime@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
-  integrity sha1-llxwWGaOgrVde/4E/yM3vItWR/4=
-  dependencies:
-    core-js "^2.4.0"
-    regenerator-runtime "^0.11.0"
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -813,7 +838,7 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@~2.20.0:
+commander@^2.11.0, commander@~2.20.0:
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
@@ -845,15 +870,18 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
-core-js@^2.4.0, core-js@^2.5.0:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
-  integrity sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==
-
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
+
+cross-fetch@^2.2.2:
+  version "2.2.3"
+  resolved "https://registry.npmjs.org/cross-fetch/-/cross-fetch-2.2.3.tgz#e8a0b3c54598136e037f8650f8e823ccdfac198e"
+  integrity sha512-PrWWNH3yL2NYIb/7WF/5vFG3DCQiXDOVf8k3ijatbrtnwNuhMWLC7YF7uqf53tbTFDzHIUD8oITw4Bxt8ST3Nw==
+  dependencies:
+    node-fetch "2.1.2"
+    whatwg-fetch "2.0.4"
 
 cross-spawn@^6.0.0:
   version "6.0.5"
@@ -1190,16 +1218,6 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fetch-mock@^7.3.1:
-  version "7.3.3"
-  resolved "https://registry.yarnpkg.com/fetch-mock/-/fetch-mock-7.3.3.tgz#d1abdf309cdef8adb4b0fc0596d3f97fcfbd4528"
-  integrity sha512-MHKcwZ4n9TmnfnVfelUBrrfxtC9tztafIR+F8l/Yu9N+y48fU1BAwj3iSxhYFYELVw73rCZh2DPWtWCekY/t+w==
-  dependencies:
-    babel-polyfill "^6.26.0"
-    glob-to-regexp "^0.4.0"
-    path-to-regexp "^2.2.1"
-    whatwg-url "^6.5.0"
-
 fill-range@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-4.0.0.tgz#d544811d428f98eb06a63dc402d2403c328c38f7"
@@ -1305,11 +1323,6 @@ getpass@^0.1.1:
   integrity sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=
   dependencies:
     assert-plus "^1.0.0"
-
-glob-to-regexp@^0.4.0:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
-  integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
 glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
   version "7.1.4"
@@ -1817,6 +1830,14 @@ jest-environment-node@^24.8.0:
     jest-mock "^24.8.0"
     jest-util "^24.8.0"
 
+jest-fetch-mock@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-2.1.2.tgz#1260b347918e3931c4ec743ceaf60433da661bd0"
+  integrity sha512-tcSR4Lh2bWLe1+0w/IwvNxeDocMI/6yIA2bijZ0fyWxC4kQ18lckQ1n7Yd40NKuisGmcGBRFPandRXrW/ti/Bw==
+  dependencies:
+    cross-fetch "^2.2.2"
+    promise-polyfill "^7.1.1"
+
 jest-get-type@^24.8.0:
   version "24.8.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-24.8.0.tgz#a7440de30b651f5a70ea3ed7ff073a32dfe646fc"
@@ -2233,9 +2254,9 @@ lodash@^4.17.11:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
-loose-envify@^1.0.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
-  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
+  resolved "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
@@ -2439,6 +2460,11 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
+node-fetch@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
+  integrity sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=
+
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
@@ -2546,9 +2572,9 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-object-assign@^4.1.0:
+object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
-  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+  resolved "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
 object-copy@^0.1.0:
@@ -2725,11 +2751,6 @@ path-parse@^1.0.6:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
 
-path-to-regexp@^2.2.1:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-2.4.0.tgz#35ce7f333d5616f1c1e1bfe266c3aba2e5b2e704"
-  integrity sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==
-
 path-type@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
@@ -2796,6 +2817,11 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
+promise-polyfill@^7.1.1:
+  version "7.1.2"
+  resolved "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-7.1.2.tgz#ab05301d8c28536301622d69227632269a70ca3b"
+  integrity sha512-FuEc12/eKqqoRYIGBrUptCBRhobL19PS2U31vMNTfyck1FxPyMfgsXyW4Mav85y/ZN1hop3hOwRlUDok23oYfQ==
+
 prompts@^2.0.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.1.0.tgz#bf90bc71f6065d255ea2bdc0fe6520485c1b45db"
@@ -2803,6 +2829,15 @@ prompts@^2.0.1:
   dependencies:
     kleur "^3.0.2"
     sisteransi "^1.0.0"
+
+prop-types@^15.6.2:
+  version "15.7.2"
+  resolved "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.8.1"
 
 psl@^1.1.24, psl@^1.1.28:
   version "1.1.33"
@@ -2842,18 +2877,37 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+react-dom@^16.8.6:
+  version "16.8.6"
+  resolved "https://registry.npmjs.org/react-dom/-/react-dom-16.8.6.tgz#71d6303f631e8b0097f56165ef608f051ff6e10f"
+  integrity sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.13.6"
+
 react-hooks-testing-library@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/react-hooks-testing-library/-/react-hooks-testing-library-0.6.0.tgz#2e96dbd32c405d8f1b3949e1fc22f6924305e28b"
   integrity sha512-VzOF4ZYMWR2B0RQgRXmxolmSMy7uvUPgmVm/CqSeyTRiITMQXiTywK65sjoIHzsQ6tW1R8hbljSYU02PgGdvCA==
-
   dependencies:
     "@testing-library/react-hooks" "~1.0.2"
 
-react-is@^16.8.4:
+react-is@^16.8.1, react-is@^16.8.4:
   version "16.8.6"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
+  resolved "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
+
+react@^16.8.6:
+  version "16.8.6"
+  resolved "https://registry.npmjs.org/react/-/react-16.8.6.tgz#ad6c3a9614fd3a4e9ef51117f54d888da01f2bbe"
+  integrity sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.13.6"
 
 read-pkg-up@^4.0.0:
   version "4.0.0"
@@ -2891,16 +2945,6 @@ realpath-native@^1.1.0:
   integrity sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==
   dependencies:
     util.promisify "^1.0.0"
-
-regenerator-runtime@^0.10.5:
-  version "0.10.5"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
-  integrity sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=
-
-regenerator-runtime@^0.11.0:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
-  integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
 
 regenerator-runtime@^0.13.2:
   version "0.13.2"
@@ -3069,6 +3113,14 @@ sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
+
+scheduler@^0.13.6:
+  version "0.13.6"
+  resolved "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz#466a4ec332467b31a91b9bf74e5347072e4cd889"
+  integrity sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
 
 "semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5, semver@^5.5.0, semver@^5.6.0:
   version "5.7.0"
@@ -3574,6 +3626,11 @@ w3c-hr-time@^1.0.1:
   dependencies:
     browser-process-hrtime "^0.1.2"
 
+wait-for-expect@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-1.2.0.tgz#fdab6a26e87d2039101db88bff3d8158e5c3e13f"
+  integrity sha512-EJhKpA+5UHixduMBEGhTFuLuVgQBKWxkFbefOdj2bbk2/OpA5Opsc4aUTGmF+qJ+v3kTGxDRNYwKaT4j6g5n8Q==
+
 walker@^1.0.7, walker@~1.0.5:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"
@@ -3593,12 +3650,17 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
   dependencies:
     iconv-lite "0.4.24"
 
+whatwg-fetch@2.0.4:
+  version "2.0.4"
+  resolved "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
+  integrity sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==
+
 whatwg-mimetype@^2.1.0, whatwg-mimetype@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
   integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
 
-whatwg-url@^6.4.1, whatwg-url@^6.5.0:
+whatwg-url@^6.4.1:
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.5.0.tgz#f2df02bff176fd65070df74ad5ccbb5a199965a8"
   integrity sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==


### PR DESCRIPTION
I've been looking for something to handle my http requests when I came across this.  I'm big on typescript but I noticed that the types were not quite right and I would like to suggest a few improvements.

For example [this line](https://github.com/alex-cory/use-http/blob/master/src/useFetch.ts#L48):

```javascript
const [data, setData] = useState(null);  // ts will infer the type for data as null
```

So when I try and use this in a typescript project that consumes `use-http`.
```javascript
const { data, loading, error } = useFetch("http://url.com");  // data is typed as null
```

I've added a generic type parameter to useFetch that defaults to any

```javascript
export function useFetch<TData = any>(arg1: useFetchArg1, arg2?: Options | RequestInit): UseFetch<TData> {
....
const [data, setData] = useState<TData>(null);  // now the user can supply a type
```

For example:

```javascript
const { loading, data, error } = useFetch<{ name: string, age: number }>('https://example.com', { onMount: true });
```

I've also got the tests running.

I like the look of the project and hope this could help.




