### PR TITLE
isolate and simplify the creation of the options object

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-hooks-testing-library": "^0.6.0",
-    "react-test-renderer": "^16.8.6",
     "ts-jest": "^24.0.0",
     "typescript": "^3.4.5"
   },

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-hooks-testing-library": "^0.6.0",
+    "react-test-renderer": "^16.8.6",
     "ts-jest": "^24.0.0",
     "typescript": "^3.4.5"
   },

--- a/src/FetchContext.ts
+++ b/src/FetchContext.ts
@@ -1,11 +1,5 @@
 import { createContext } from 'react'
-
-
-type FetchContextTypes = {
-  url?: string,
-  options?: RequestInit | undefined,
-  graphql?: boolean,
-}
+import { FetchContextTypes } from "./types";
 
 export const FetchContext = createContext<FetchContextTypes>({
   url: typeof window !== 'undefined' ? window.location.origin : '',

--- a/src/__tests__/configuration.test.ts
+++ b/src/__tests__/configuration.test.ts
@@ -1,10 +1,37 @@
 import { makeConfig } from "../makeConfig";
 import { renderHook } from '@testing-library/react-hooks';
 
+
 describe.only('use-http configuration', () => {
-  it('should create a default configuration with no arguments', () => {
+  it('should create config from a single url argument', () => {
     const config = renderHook(() => makeConfig({}, "http://blah.com"))
 
-    expect(config.result.current).toEqual({ onMount: false, url: "http://blah.com" })
+    expect(config.result.current).toEqual({ onMount: false, url: "http://blah.com", headers: { 'Content-Type': 'application/json' } })
+  });
+
+  it('should create a config object from an options object', () => {
+    const config = renderHook(() => makeConfig({}, { url: "http://blah.com" }))
+
+    expect(config.result.current).toEqual({ onMount: false, url: "http://blah.com", headers: { 'Content-Type': 'application/json' } })
+  })
+
+  it('should set onMount true', () => {
+    const config1 = renderHook(() => makeConfig({}, "http://blah.com", { onMount: true }))
+
+    expect(config1.result.current).toEqual({ onMount: true, url: "http://blah.com", headers: { 'Content-Type': 'application/json' } })
+
+    const config2 = renderHook(() => makeConfig({}, { url: "http://blah.com", onMount: true }))
+
+    expect(config2.result.current).toEqual({ onMount: true, url: "http://blah.com", headers: { 'Content-Type': 'application/json' } })
+  })
+
+  it('should set headers', () => {
+    const config1 = renderHook(() => makeConfig({}, "http://blah.com", { headers: { 'Content-Type': 'multipart/form-data' } }))
+
+    expect(config1.result.current).toEqual({ onMount: false, url: "http://blah.com", headers: { 'Content-Type': 'multipart/form-data' } })
+
+    const config2 = renderHook(() => makeConfig({}, { url: "http://blah.com", onMount: false, headers: { 'Content-Type': 'multipart/form-data' } }))
+
+    expect(config2.result.current).toEqual({ onMount: false, url: "http://blah.com", headers: { 'Content-Type': 'multipart/form-data' } })
   });
 });

--- a/src/__tests__/configuration.test.ts
+++ b/src/__tests__/configuration.test.ts
@@ -1,0 +1,5 @@
+describe('use-http configuration', () => {
+  it('should create a default configuration with no arguments', () => {
+    
+  });
+});

--- a/src/__tests__/configuration.test.ts
+++ b/src/__tests__/configuration.test.ts
@@ -1,5 +1,10 @@
-describe('use-http configuration', () => {
+import { makeConfig } from "../makeConfig";
+import { renderHook } from '@testing-library/react-hooks';
+
+describe.only('use-http configuration', () => {
   it('should create a default configuration with no arguments', () => {
-    
+    const config = renderHook(() => makeConfig({}, "http://blah.com"))
+
+    expect(config.result.current).toEqual({ onMount: false, url: "http://blah.com" })
   });
 });

--- a/src/__tests__/configuration.test.ts
+++ b/src/__tests__/configuration.test.ts
@@ -1,6 +1,5 @@
 import { makeConfig } from "../makeConfig";
 
-
 describe.only('use-http configuration', () => {
   it('should create config from a single url argument', () => {
     const config = makeConfig({}, "http://blah.com")

--- a/src/__tests__/configuration.test.ts
+++ b/src/__tests__/configuration.test.ts
@@ -1,37 +1,36 @@
 import { makeConfig } from "../makeConfig";
-import { renderHook } from '@testing-library/react-hooks';
 
 
 describe.only('use-http configuration', () => {
   it('should create config from a single url argument', () => {
-    const config = renderHook(() => makeConfig({}, "http://blah.com"))
+    const config = makeConfig({}, "http://blah.com")
 
-    expect(config.result.current).toEqual({ onMount: false, url: "http://blah.com", headers: { 'Content-Type': 'application/json' } })
+    expect(config).toEqual({ onMount: false, url: "http://blah.com", headers: { 'Content-Type': 'application/json' } })
   });
 
   it('should create a config object from an options object', () => {
-    const config = renderHook(() => makeConfig({}, { url: "http://blah.com" }))
+    const config = makeConfig({}, { url: "http://blah.com" })
 
-    expect(config.result.current).toEqual({ onMount: false, url: "http://blah.com", headers: { 'Content-Type': 'application/json' } })
+    expect(config).toEqual({ onMount: false, url: "http://blah.com", headers: { 'Content-Type': 'application/json' } })
   })
 
   it('should set onMount true', () => {
-    const config1 = renderHook(() => makeConfig({}, "http://blah.com", { onMount: true }))
+    const config1 = makeConfig({}, "http://blah.com", { onMount: true })
 
-    expect(config1.result.current).toEqual({ onMount: true, url: "http://blah.com", headers: { 'Content-Type': 'application/json' } })
+    expect(config1).toEqual({ onMount: true, url: "http://blah.com", headers: { 'Content-Type': 'application/json' } })
 
-    const config2 = renderHook(() => makeConfig({}, { url: "http://blah.com", onMount: true }))
+    const config2 = makeConfig({}, { url: "http://blah.com", onMount: true })
 
-    expect(config2.result.current).toEqual({ onMount: true, url: "http://blah.com", headers: { 'Content-Type': 'application/json' } })
+    expect(config2).toEqual({ onMount: true, url: "http://blah.com", headers: { 'Content-Type': 'application/json' } })
   })
 
   it('should set headers', () => {
-    const config1 = renderHook(() => makeConfig({}, "http://blah.com", { headers: { 'Content-Type': 'multipart/form-data' } }))
+    const config1 = makeConfig({}, "http://blah.com", { headers: { 'Content-Type': 'multipart/form-data' } })
 
-    expect(config1.result.current).toEqual({ onMount: false, url: "http://blah.com", headers: { 'Content-Type': 'multipart/form-data' } })
+    expect(config1).toEqual({ onMount: false, url: "http://blah.com", headers: { 'Content-Type': 'multipart/form-data' } })
 
-    const config2 = renderHook(() => makeConfig({}, { url: "http://blah.com", onMount: false, headers: { 'Content-Type': 'multipart/form-data' } }))
+    const config2 = makeConfig({}, { url: "http://blah.com", onMount: false, headers: { 'Content-Type': 'multipart/form-data' } })
 
-    expect(config2.result.current).toEqual({ onMount: false, url: "http://blah.com", headers: { 'Content-Type': 'multipart/form-data' } })
+    expect(config2).toEqual({ onMount: false, url: "http://blah.com", headers: { 'Content-Type': 'multipart/form-data' } })
   });
 });

--- a/src/makeConfig.ts
+++ b/src/makeConfig.ts
@@ -2,6 +2,10 @@ import { useCallback } from "react"
 import { Options, FetchContextTypes, OptionsMaybeURL, NoUrlOptions } from './types'
 import { isString, isObject, invariant, pullOutRequestInit } from "./utils"
 
+export const DefaultOptions: NoUrlOptions = {
+  onMount: false
+}
+
 function makeConfig(context: FetchContextTypes, urlOrOptions?: string | OptionsMaybeURL, optionsNoURLs?: NoUrlOptions): Options {
   let onMount = false
   let url = context.url || ''
@@ -9,7 +13,7 @@ function makeConfig(context: FetchContextTypes, urlOrOptions?: string | OptionsM
   let requestInit: RequestInit = {};
 
   const handleUseFetchOptions = useCallback((useFetchOptions?: OptionsMaybeURL): void => {
-    const opts = useFetchOptions || {} as Options
+    const opts = useFetchOptions as Options
     if ('onMount' in opts) onMount = opts.onMount as boolean
     if ('url' in opts) url = opts.url as string
   }, [])
@@ -39,8 +43,15 @@ function makeConfig(context: FetchContextTypes, urlOrOptions?: string | OptionsM
   return {
     url,
     onMount,
+    headers: {
+      // default content types http://bit.ly/2N2ovOZ
+      // Accept: 'application/json', 
+      'Content-Type': 'application/json',
+      ...(context.options || {}).headers,
+      ...options.headers
+    },
     ...options,
-    ...requestInit
+    ...requestInit,
   } as Options;
 }
 

--- a/src/makeConfig.ts
+++ b/src/makeConfig.ts
@@ -1,0 +1,48 @@
+import { useCallback } from "react"
+import { Options, FetchContextTypes, OptionsMaybeURL, NoUrlOptions } from './types'
+import { isString, isObject, invariant, pullOutRequestInit } from "./utils"
+
+function makeConfig(context: FetchContextTypes, urlOrOptions?: string | OptionsMaybeURL, optionsNoURLs?: NoUrlOptions): Options {
+  let onMount = false
+  let url = context.url || ''
+  let options: Partial<Options> = {}
+  let requestInit: RequestInit = {};
+
+  const handleUseFetchOptions = useCallback((useFetchOptions?: OptionsMaybeURL): void => {
+    const opts = useFetchOptions || {} as Options
+    if ('onMount' in opts) onMount = opts.onMount as boolean
+    if ('url' in opts) url = opts.url as string
+  }, [])
+
+  // ex: useFetch('https://url.com', { onMount: true })
+  if (isString(urlOrOptions) && isObject(optionsNoURLs)) {
+    url = urlOrOptions as string
+    requestInit = pullOutRequestInit(optionsNoURLs)
+    handleUseFetchOptions(optionsNoURLs)
+
+    // ex: useFetch('https://url.com')
+  } else if (isString(urlOrOptions) && optionsNoURLs === undefined) {
+    url = urlOrOptions as string
+
+    // ex: useFetch({ onMount: true }) OR useFetch({ url: 'https://url.com' })
+  } else if (isObject(urlOrOptions)) {
+    invariant(!optionsNoURLs, 'You cannot have a 2nd parameter of useFetch when your first argument is a object config.')
+    let optsWithURL = urlOrOptions as Options
+    invariant(!!context.url || !!optsWithURL.url, 'You have to either set a URL in your options config or set a global URL in your <Provider url="https://url.com"></Provider>')
+    requestInit = pullOutRequestInit(urlOrOptions)
+    handleUseFetchOptions(urlOrOptions as OptionsMaybeURL)
+  }
+
+  options.url = url
+  options.onMount = onMount
+
+  return {
+    url,
+    onMount,
+    ...options,
+    ...requestInit
+  } as Options;
+}
+
+export { makeConfig }
+export default makeConfig

--- a/src/makeConfig.ts
+++ b/src/makeConfig.ts
@@ -1,5 +1,5 @@
 import { Options, FetchContextTypes, OptionsMaybeURL, NoUrlOptions } from './types'
-import { isString, isObject, pullOutRequestInit } from "./utils"
+import { isString, isObject, pullOutRequestInit, invariant } from "./utils"
 
 export const DefaultOptions: NoUrlOptions = {
   onMount: false
@@ -9,10 +9,7 @@ function makeConfig(context: FetchContextTypes, urlOrOptions?: string | OptionsM
   let options: Partial<Options> = {}
   let requestInit: RequestInit = {}
 
-  if (isObject(urlOrOptions) && isObject(optionsNoURLs)) {
-    // TODO: I could not get the utils/invariant to work with the condition isObject(urlOrOptions) && isObject(optionsNoURLs)
-    throw new Error('You cannot have a 2nd parameter of useFetch when your first argument is a object config.')
-  }
+  invariant(!(isObject(urlOrOptions) && isObject(optionsNoURLs)), 'You cannot have a 2nd parameter of useFetch when your first argument is an object config.')
 
   const getUrl = (): string => {
     if (isString(urlOrOptions)) {

--- a/src/makeConfig.ts
+++ b/src/makeConfig.ts
@@ -20,10 +20,6 @@ function makeConfig(context: FetchContextTypes, urlOrOptions?: string | OptionsM
       return urlOrOptions.url;
     }
 
-    if (isObject(urlOrOptions) && !!urlOrOptions.url) {
-      return urlOrOptions.url;
-    }
-
     if (!!context.url) {
       return context.url;
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,7 +44,9 @@ export type Options = {
   url: string,
 } & RequestInit
 
-export type OptionsMaybeURL = Omit<Options, 'url'> & { url?: string }
+export type NoUrlOptions = Omit<Options, 'url'>
+
+export type OptionsMaybeURL = NoUrlOptions & Partial<Pick<Options, 'url'>> & { url?: string }
 
 // TODO: this is still yet to be implemented
 export type OptionsOverwriteWithContext = (options: Options) => Options

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,13 @@ export type NoArgs = () => Promise<void>
 // type RouteAndBody = (routeOrBody?: string | object, body?: object) => Promise<void>
 type FetchData = BodyOnly | RouteOnly | RouteAndBodyOnly | NoArgs
 
+export type FetchContextTypes = {
+  url?: string,
+  options?: RequestInit | undefined,
+  graphql?: boolean,
+}
+
+
 export type FetchCommands = {
   get: RouteOnly & NoArgs,
   post: FetchData,
@@ -42,6 +49,7 @@ export type Options = {
   onMount?: boolean,
   timeout?: number,
   url: string,
+  signal?: AbortSignal
 } & RequestInit
 
 export type NoUrlOptions = Omit<Options, 'url'>

--- a/src/useDelete.ts
+++ b/src/useDelete.ts
@@ -1,9 +1,9 @@
 import { useContext } from 'react'
 import useFetch, { FetchContext } from '.'
-import { HTTPMethod, Options } from './types'
+import { HTTPMethod, NoUrlOptions } from './types'
 import { useURLRequiredInvariant } from './utils'
 
-export const useDelete = <TData = any>(url?: string, options?: Omit<Options, 'url'>) => {
+export const useDelete = <TData = any>(url?: string, options?: NoUrlOptions) => {
   const context = useContext(FetchContext)
 
   useURLRequiredInvariant(!!url || !!context.url, 'useDelete')

--- a/src/useFetch.ts
+++ b/src/useFetch.ts
@@ -1,27 +1,32 @@
 import { useEffect, useState, useCallback, useRef, useContext, useMemo } from 'react'
 import FetchContext from './FetchContext'
-import { HTTPMethod, Options, OptionsMaybeURL, UseFetch, FetchCommands, DestructuringCommands, UseFetchResult, NoArgs } from './types'
+import { HTTPMethod, Options, OptionsMaybeURL, UseFetch, FetchCommands, DestructuringCommands, UseFetchResult, NoArgs, NoUrlOptions } from './types'
 import { BodyOnly, RouteAndBodyOnly, RouteOnly } from './types'
 import { invariant, isObject, isString, pullOutRequestInit } from './utils'
 
+export const useFetchDefaults: Partial<Options> = {
+  onMount: false,
+  
+}
+
 // No <Provider url='example.com' />
-function useFetch<TData = any>(url: string, options?: Omit<Options, 'url'>): UseFetch<TData>
+function useFetch<TData = any>(url: string, options?: NoUrlOptions): UseFetch<TData>
 function useFetch<TData = any>(options: Options): UseFetch<TData>
 // With <Provider url='example.com' />
 // options should be extended. In future maybe have options callback to completely overwrite options
 // i.e. useFetch('ex.com', oldOptions => ({ ...newOptions })) to overwrite
-function useFetch<TData = any>(url?: string, options?: Omit<Options, 'url'>): UseFetch<TData>
+function useFetch<TData = any>(url?: string, options?: NoUrlOptions): UseFetch<TData>
 function useFetch<TData = any>(options?: OptionsMaybeURL): UseFetch<TData>
 
 // TODO: handle context.graphql
-function useFetch<TData = any>(urlOrOptions?: string | OptionsMaybeURL, optionsNoURLs?: Omit<Options, 'url'>): UseFetch<TData> {
+function useFetch<TData = any>(urlOrOptions?: string | OptionsMaybeURL, optionsNoURLs?: NoUrlOptions): UseFetch<TData> {
   const context = useContext(FetchContext)
 
   invariant(!!urlOrOptions || !!context.url, 'The first argument of useFetch is required unless you have a global url setup like: <Provider url="https://example.com"></Provider>')
 
-  let url: string = context.url || ''
+  let url = context.url || ''
   let options: RequestInit = {}
-  let onMount: boolean = false
+  let onMount = false
   // let timeout: number = 10 // TODO: not implemented
 
   const handleUseFetchOptions = useCallback((useFetchOptions?: OptionsMaybeURL): void => {
@@ -37,11 +42,11 @@ function useFetch<TData = any>(urlOrOptions?: string | OptionsMaybeURL, optionsN
     options = pullOutRequestInit(optionsNoURLs)
     handleUseFetchOptions(optionsNoURLs)
 
-  // ex: useFetch('https://url.com')
+    // ex: useFetch('https://url.com')
   } else if (isString(urlOrOptions) && optionsNoURLs === undefined) {
     url = urlOrOptions as string
 
-  // ex: useFetch({ onMount: true }) OR useFetch({ url: 'https://url.com' })
+    // ex: useFetch({ onMount: true }) OR useFetch({ url: 'https://url.com' })
   } else if (isObject(urlOrOptions)) {
     invariant(!optionsNoURLs, 'You cannot have a 2nd parameter of useFetch when your first argument is a object config.')
     let optsWithURL = urlOrOptions as Options
@@ -81,21 +86,21 @@ function useFetch<TData = any>(urlOrOptions?: string | OptionsMaybeURL, optionsN
         if (isString(routeOrBody)) {
           route = routeOrBody as string;
           options.body = JSON.stringify(body || {})
-        // ex: request.post({ no: 'way' })
+          // ex: request.post({ no: 'way' })
         } else if (isObject(routeOrBody)) {
           invariant(!body, `If first argument of ${method.toLowerCase()}() is an object, you cannot have a 2nd argument. 😜`)
           options.body = JSON.stringify(routeOrBody || {})
         }
-      // GET
+        // GET
       } else {
-          invariant(!isObject(routeOrBody), 'Cannot pass a request body in a GET request')
-          // ex: request.get('/no?freaking=way')
-          if (isString(routeOrBody)) route = routeOrBody as string
+        invariant(!isObject(routeOrBody), 'Cannot pass a request body in a GET request')
+        // ex: request.get('/no?freaking=way')
+        if (isString(routeOrBody)) route = routeOrBody as string
       }
 
       try {
         setLoading(true)
-        const response = await fetch(url + route, {
+        const response = await fetch(`${url}${route}`, {
           method,
           ...context.options,
           ...options,
@@ -142,17 +147,21 @@ function useFetch<TData = any>(urlOrOptions?: string | OptionsMaybeURL, optionsN
 
   // handling onMount
   useEffect(() => {
-    const methodName = ((options.method || '') || HTTPMethod.GET).toUpperCase() as keyof FetchCommands
-    if (!!url && onMount && methodName !== HTTPMethod.GET as string) {
+    if (!onMount) {
+      return;
+    }
+    const methodName = options.method || HTTPMethod.GET;
+    // const methodName = ((options.method || '') || HTTPMethod.GET).toUpperCase() as keyof FetchCommands
+    if (!!url && methodName !== HTTPMethod.GET) {
       const req = request[methodName.toLowerCase() as keyof FetchCommands] as RouteAndBodyOnly
       req(url, options.body as BodyInit)
-    } else if (!url && onMount && methodName !== HTTPMethod.GET as string) {
+    } else if (!url && methodName !== HTTPMethod.GET as string) {
       const req = request[methodName.toLowerCase() as keyof FetchCommands] as BodyOnly
       req(options.body as BodyInit)
-    } else if (!!url && onMount) {
+    } else if (!!url) {
       const req = request[methodName.toLowerCase() as keyof FetchCommands] as RouteOnly
       req(url)
-    } else if (onMount) {
+    } else {
       const req = request[methodName.toLowerCase() as keyof FetchCommands] as NoArgs
       req()
     }

--- a/src/useFetch.ts
+++ b/src/useFetch.ts
@@ -80,13 +80,6 @@ function useFetch<TData = any>(urlOrOptions?: string | OptionsMaybeURL, optionsN
           method,
           ...context.options,
           ...options,
-          headers: {
-            // default content types http://bit.ly/2N2ovOZ
-            // Accept: 'application/json', 
-            'Content-Type': 'application/json',
-            ...(context.options || {}).headers,
-            ...options.headers
-          }
         })
         let data = null
         try {

--- a/src/useGet.ts
+++ b/src/useGet.ts
@@ -1,9 +1,9 @@
 import { useContext } from 'react'
 import useFetch, { FetchContext } from '.'
-import { HTTPMethod, Options } from './types'
+import { HTTPMethod, NoUrlOptions } from './types'
 import { useURLRequiredInvariant } from './utils'
 
-export const useGet = <TData = any>(url?: string, options?: Omit<Options, 'url'>) => {
+export const useGet = <TData = any>(url?: string, options?: NoUrlOptions) => {
   const context = useContext(FetchContext)
 
   useURLRequiredInvariant(!!url || !!context.url, 'useGet')

--- a/src/usePatch.ts
+++ b/src/usePatch.ts
@@ -1,9 +1,9 @@
 import { useContext } from 'react'
 import useFetch, { FetchContext } from '.'
-import { HTTPMethod, Options } from './types'
+import { HTTPMethod, NoUrlOptions } from './types'
 import { useURLRequiredInvariant } from './utils'
 
-export const usePatch = <TData = any>(url?: string, options?: Omit<Options, 'url'>) => {
+export const usePatch = <TData = any>(url?: string, options?: NoUrlOptions) => {
   const context = useContext(FetchContext)
 
   useURLRequiredInvariant(!!url || !!context.url, 'usePatch')

--- a/src/usePost.ts
+++ b/src/usePost.ts
@@ -1,9 +1,9 @@
 import { useContext } from 'react'
 import useFetch, { FetchContext } from '.'
-import { HTTPMethod, Options } from './types'
+import { HTTPMethod, NoUrlOptions } from './types'
 import { useURLRequiredInvariant } from './utils'
 
-export const usePost = <TData = any>(url?: string, options?: Omit<Options, 'url'>) => {
+export const usePost = <TData = any>(url?: string, options?: NoUrlOptions) => {
   const context = useContext(FetchContext)
 
   useURLRequiredInvariant(!!url || !!context.url, 'usePost')

--- a/src/usePut.ts
+++ b/src/usePut.ts
@@ -1,9 +1,9 @@
 import { useContext } from 'react'
 import useFetch, { FetchContext } from '.'
-import { HTTPMethod, Options } from './types'
+import { HTTPMethod, NoUrlOptions } from './types'
 import { useURLRequiredInvariant } from './utils'
 
-export const usePut = <TData = any>(url?: string, options?: Omit<Options, 'url'>) => {
+export const usePut = <TData = any>(url?: string, options?: NoUrlOptions) => {
   const context = useContext(FetchContext)
 
   useURLRequiredInvariant(!!url || !!context.url, 'usePut')

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,7 +19,7 @@ export const useExampleURL = (): string => {
   return useMemo(() => isBrowser ? window.location.origin : 'https://example.com', [isBrowser])
 }
 
-export const isString = (x: any) => typeof x === 'string'
+export const isString = (x: any): x is string => typeof x === 'string'
 
 // TODO: come back and fix the "anys" in this http://bit.ly/2Lm3OLi
 /**
@@ -54,7 +54,7 @@ export const pullOutRequestInit = (options?: {}): RequestInit => {
  * Determines if the given param is an object. {}
  * @param obj
  */
-export const isObject = (obj: any) => Object.prototype.toString.call(obj) === '[object Object]'
+export const isObject = (obj: any): obj is object => Object.prototype.toString.call(obj) === '[object Object]'
 
 /**
  * Used for error checking. If the condition is false, throw an error


### PR DESCRIPTION
I've created a `makeConfig` function to try and simplify the creation of the various options.

I've isolated this to make testing easier.

I've added tests and I think it is more readable but please feel free to disagree.

This is your baby, you can outright refuse if  you want.