### PR TITLE
adding `path` field to options

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,8 +153,6 @@ function Todos() {
 ```
 </details>
 
-<details open><summary><b>Destructured <code>useFetch</code></b></summary>
-
 <details open><summary>Basic Usage with `Provider`</summary>
 
 ```js
@@ -185,6 +183,8 @@ const App = () => (
 )
 ```
 </details>
+
+<details open><summary><b>Destructured <code>useFetch</code></b></summary>
 
 ```js
 var [request, response, loading, error] = useFetch('https://example.com')

--- a/README.md
+++ b/README.md
@@ -155,6 +155,37 @@ function Todos() {
 
 <details open><summary><b>Destructured <code>useFetch</code></b></summary>
 
+<details open><summary>Basic Usage with `Provider`</summary>
+
+```js
+import useFetch, { Provider } from 'use-http'
+
+function Todos() {
+  const { loading, error, data } = useFetch({
+    onMount: true,
+    path: '/todos',
+    data: []
+  })
+
+  return (
+    <>
+      {error && 'Error!'}
+      {loading && 'Loading...'}
+      {!loading && data.map(todo => (
+        <div key={todo.id}>{todo.title}</div>
+      )}
+    </>
+  )
+}
+
+const App = () => (
+  <Provider url='https://example.com'>
+    <Todos />
+  </Provider>
+)
+```
+</details>
+
 ```js
 var [request, response, loading, error] = useFetch('https://example.com')
 

--- a/README.md
+++ b/README.md
@@ -522,8 +522,12 @@ const App = () => {
     timeout: 10000,      // amount of time period before erroring out
     onServer: true,      // potential idea to fetch on server instead of just having `loading` state. Not sure if this is a good idea though
     interceptors: {      
-      request(opts) {}   // i.e. if you need to do some kind of authentication before a request
-      response(opts) {}  // i.e. if you want to camelCase all fields in a response everytime
+      request(opts) { // i.e. if you need to do some kind of authentication before a request
+        return opts
+      }   
+      response(res) { // i.e. if you want to camelCase all fields in a response everytime
+        return res
+      }  
     }
   })
   ```

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ function Todos() {
 ```
 </details>
 
-<details open><summary>Basic Usage with `Provider`</summary>
+<details open><summary>Basic Usage with <code>Provider</code></summary>
 
 ```js
 import useFetch, { Provider } from 'use-http'

--- a/docs/README.md
+++ b/docs/README.md
@@ -137,6 +137,36 @@ function Todos() {
 }
 ```
 
+Basic Example With Provider
+---------------------------
+```js
+import useFetch, { Provider } from 'use-http'
+
+function Todos() {
+  const { loading, error, data } = useFetch({ // accepts all `fetch` options
+    onMount: true,  // will fire on componentDidMount (GET by default)
+    path: '/todos',
+    data: []        // default for `data` will be an array instead of undefined
+  })
+
+  return (
+    <>
+      {error && 'Error!'}
+      {loading && 'Loading...'}
+      {!loading && data.map(todo => (
+        <div key={todo.id}>{todo.title}</div>
+      )}
+    </>
+  )
+}
+
+const App = () => (
+  <Provider url='https://example.com'>
+    <Todos />
+  </Provider>
+)
+```
+
 Destructured
 -------------
 ```js

--- a/src/__tests__/useCustomOptions.test.tsx
+++ b/src/__tests__/useCustomOptions.test.tsx
@@ -20,7 +20,8 @@ describe('useCustomOptions: general usages', (): void => {
       url: 'https://example.com',
       onMount: false,
       loading: false,
-      data: undefined
+      data: undefined,
+      path: ''
     })
   })
 
@@ -35,7 +36,8 @@ describe('useCustomOptions: general usages', (): void => {
       url: 'https://example.com',
       onMount: true,
       loading: true,
-      data: undefined
+      data: undefined,
+      path: ''
     })
   })
 
@@ -45,7 +47,8 @@ describe('useCustomOptions: general usages', (): void => {
       url: 'https://example.com',
       onMount: false,
       loading: false,
-      data: undefined
+      data: undefined,
+      path: ''
     })
   })
 
@@ -58,7 +61,8 @@ describe('useCustomOptions: general usages', (): void => {
       url: 'https://cool.com',
       onMount: true,
       loading: true,
-      data: undefined
+      data: undefined,
+      path: ''
     })
   })
 
@@ -71,7 +75,8 @@ describe('useCustomOptions: general usages', (): void => {
       url: 'https://example.com',
       onMount: false,
       loading: false,
-      data: []
+      data: [],
+      path: ''
     })
   })
 
@@ -88,7 +93,8 @@ describe('useCustomOptions: general usages', (): void => {
       url: 'http://localhost',
       onMount: false,
       loading: false,
-      data: undefined
+      data: undefined,
+      path: ''
     })
   })
 })

--- a/src/__tests__/useFetch.test.tsx
+++ b/src/__tests__/useFetch.test.tsx
@@ -183,6 +183,20 @@ describe('useFetch - BROWSER - with <Provider />', (): void => {
     expect(result.current.loading).toBe(false)
     expect(result.current.data).toMatchObject(expected)
   })
+
+  it('should execute GET using Provider url: useFetch({ path: "/people", onMount: true })', async (): Promise<
+    void
+  > => {
+    const { result, waitForNextUpdate } = renderHook(
+      () => useFetch({ path: '/people', onMount: true }),
+      { wrapper: wrapper as React.ComponentType }
+    )
+    expect(result.current.loading).toBe(true)
+    await waitForNextUpdate()
+    expect(result.current.loading).toBe(false)
+    expect(result.current.data).toMatchObject(expected)
+    // TODO: test if you do a post('/alex'), if the url is /people/alex
+  })
 })
 
 describe('useFetch - BROWSER - with <Provider /> - Managed State', (): void => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,6 +83,7 @@ export type UseFetch<TData> = UseFetchArrayReturn<TData> &
 export interface CustomOptions {
   onMount?: boolean
   timeout?: number
+  path?: string
   url: string
   loading?: boolean
   data?: any

--- a/src/useCustomOptions.ts
+++ b/src/useCustomOptions.ts
@@ -22,6 +22,7 @@ export default function useCustomOptions(
 ): CustomOptions {
   const context = useContext(FetchContext)
   const { isServer } = useSSR()
+
   invariant(
     !(isObject(urlOrOptions) && isObject(optionsNoURLs)),
     'You cannot have a 2nd parameter of useFetch when your first argument is an object config.',
@@ -57,5 +58,11 @@ export default function useCustomOptions(
     if (isObject(optionsNoURLs)) return optionsNoURLs.data
   }, [urlOrOptions, optionsNoURLs])
 
-  return { url, onMount, loading, data }
+  const path = useMemo((): string => {
+    if (isObject(urlOrOptions) && urlOrOptions.path) return urlOrOptions.path as string
+    if (isObject(optionsNoURLs) && optionsNoURLs.path) return optionsNoURLs.path as string
+    return ''
+  }, [urlOrOptions, optionsNoURLs])
+
+  return { url, onMount, loading, data, path }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1840,9 +1840,9 @@ growly@^1.3.0:
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
 handlebars@^4.1.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.3.2.tgz#c10366a4300f708f78a421472c5d7851dbe886ab"
-  integrity sha512-LuccMnDrKB72bbClEIucoBNAIMpqmWvIGSKNEngDcYFT6hlCq7ZoCWc26ZT9mr6tfWTJeTswSldoI5LOeezzDQ==
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.3.3.tgz#56dd05fe33d6bd8a7d797351c39a0cdcfd576be5"
+  integrity sha512-VupOxR91xcGojfINrzMqrvlyYbBs39sXIrWa7YdaQWeBudOlvKEGvCczMfJPgnuwHE/zyH1M6J+IUP6cgDVyxg==
   dependencies:
     neo-async "^2.6.0"
     optimist "^0.6.1"


### PR DESCRIPTION
This allows us to have a way to call an endpoint `onMount` when we have the url in context
```js
const App = () => {
  const [request, response] = useFetch({
    path: '/todos',
    onMount: true,
    data: []
  })
  
  return (
    <>
      {request.error && 'Error...'}
      {request.loading && 'Loading...'}
      {!request.loading && response.data.map(todo => <div>{todo.title}</div>)}
    </>
  )
}

```