### PR TITLE
ReactNode typings

### DIFF
--- a/src/Provider.tsx
+++ b/src/Provider.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, ReactNode } from 'react'
+import React, { useMemo, ReactElement } from 'react'
 import useSSR from 'use-ssr'
 import FetchContext from './FetchContext'
 import { FetchContextTypes, FetchProviderProps } from './types'
@@ -8,7 +8,7 @@ export const Provider = ({
   options,
   graphql = false,
   children,
-}: FetchProviderProps): ReactNode => {
+}: FetchProviderProps): ReactElement => {
   const { isBrowser } = useSSR()
 
   const defaults = useMemo(

--- a/src/__tests__/useFetch.test.tsx
+++ b/src/__tests__/useFetch.test.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react'
+import React, { ReactElement, ReactNode } from 'react'
 import { useFetch, Provider } from '..'
 import { cleanup } from '@testing-library/react'
 import { FetchMock } from 'jest-fetch-mock'
@@ -46,7 +46,7 @@ describe('useFetch - BROWSER - basic functionality', (): void => {
     age: 29,
   }
 
-  const wrapper = ({ children }: { children: ReactNode }) => <Provider url="https://example.com">{children}</Provider>
+  const wrapper = ({ children }: { children?: ReactNode }): ReactElement => <Provider url="https://example.com">{children}</Provider>
 
   afterEach((): void => {
     cleanup()
@@ -120,7 +120,7 @@ describe('useFetch - BROWSER - with <Provider />', (): void => {
     age: 29,
   }
 
-  const wrapper = ({ children }: { children?: ReactNode }): ReactNode => (
+  const wrapper = ({ children }: { children?: ReactNode }): ReactElement => (
     <Provider url='https://example.com'>{children}</Provider>
   )
 
@@ -230,7 +230,7 @@ describe('useFetch - BROWSER - with <Provider />', (): void => {
 })
 
 describe('timeouts', (): void => {
-  const wrapper = ({ children }: { children?: ReactNode }): ReactNode => (
+  const wrapper = ({ children }: { children?: ReactNode }): ReactElement => (
     <Provider url='https://example.com'>{children}</Provider>
   )
 
@@ -326,7 +326,7 @@ describe('timeouts', (): void => {
 describe('useFetch - BROWSER - with <Provider /> - Managed State', (): void => {
   const expected = { title: 'Alex Cory' }
 
-  const wrapper = ({ children }: { children?: ReactNode }): ReactNode => (
+  const wrapper = ({ children }: { children?: ReactNode }): ReactElement => (
     <Provider url='https://example.com'>{children}</Provider>
   )
 
@@ -373,7 +373,7 @@ describe('useFetch - BROWSER - interceptors', (): void => {
   const snake_case = { title: 'Alex Cory', first_name: 'Alex' }
   const expected = { title: 'Alex Cory', firstName: 'Alex' }
 
-  const wrapper = ({ children }: { children?: ReactNode }): ReactNode => {
+  const wrapper = ({ children }: { children?: ReactNode }): ReactElement => {
     const options = {
       interceptors: {
         response(res: Res<any>): Res<any> {
@@ -425,7 +425,7 @@ describe('useFetch - BROWSER - Overwrite Global Options set in Provider', (): vo
     Authorization: 'Bearer TOKEN'
   }
 
-  const wrapper = ({ children }: { children?: ReactNode }): ReactNode => {
+  const wrapper = ({ children }: { children?: ReactNode }): ReactElement => {
     const options = { headers: providerHeaders }
     return <Provider url='https://example.com' options={options}>{children}</Provider>
   }
@@ -554,7 +554,7 @@ describe('useFetch - BROWSER - errors', (): void => {
     expect(result.current.data).toEqual([])
   })
 
-  const wrapperCustomError = ({ children }: { children?: ReactNode }): ReactNode => {
+  const wrapperCustomError = ({ children }: { children?: ReactNode }): ReactElement => {
     const options = {
       interceptors: {
         response(res: Res<any>): Res<any> {

--- a/src/__tests__/useFetchArgs.test.tsx
+++ b/src/__tests__/useFetchArgs.test.tsx
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react-hooks'
 import useFetchArgs, { useFetchArgsDefaults } from '../useFetchArgs'
-import { ReactNode } from 'react'
+import { ReactElement, ReactNode } from 'react'
 import { Provider } from '..'
 import React from 'react'
 import { isServer } from '../utils'
@@ -8,7 +8,7 @@ import { isServer } from '../utils'
 describe('useFetchArgs: general usages', (): void => {
   if (isServer) return
 
-  const wrapper = ({ children }: { children?: ReactNode }): ReactNode => (
+  const wrapper = ({ children }: { children?: ReactNode }): ReactElement => (
     <Provider url='https://example.com'>{children}</Provider>
   )
 
@@ -96,7 +96,7 @@ describe('useFetchArgs: general usages', (): void => {
   it('should have a default `url` if no URL is set in Provider', (): void => {
     if (isServer) return
 
-    const wrapper2 = ({ children }: { children?: ReactNode }): ReactNode => (
+    const wrapper2 = ({ children }: { children?: ReactNode }): ReactElement => (
       <Provider>{children}</Provider>
     )
 
@@ -124,7 +124,7 @@ describe('useFetchArgs: general usages', (): void => {
       }
     }
 
-    const wrapper2 = ({ children }: { children?: ReactNode }): ReactNode => (
+    const wrapper2 = ({ children }: { children?: ReactNode }): ReactElement => (
       <Provider url='https://example.com' options={{ interceptors }}>{children}</Provider>
     )
 
@@ -191,7 +191,7 @@ describe('useFetchArgs: general usages', (): void => {
 
   it('should create custom options and use the global options instead of defaults', (): void => {
     const options = { headers: { 'Content-Type': 'application/text' } }
-    const wrapper = ({ children }: { children?: ReactNode }): ReactNode => (
+    const wrapper = ({ children }: { children?: ReactNode }): ReactElement => (
       <Provider options={options}>{children}</Provider>
     )
     const { result } = renderHook((): any => useFetchArgs(), { wrapper })
@@ -213,7 +213,7 @@ describe('useFetchArgs: general usages', (): void => {
         'Content-Type': 'application/text',
       },
     }
-    const wrapper = ({ children }: { children?: ReactNode }): ReactNode => (
+    const wrapper = ({ children }: { children?: ReactNode }): ReactElement => (
       <Provider options={options}>{children}</Provider>
     )
     const overwriteProviderOptions = {

--- a/src/__tests__/useFetchArgs.test.tsx
+++ b/src/__tests__/useFetchArgs.test.tsx
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react-hooks'
 import useFetchArgs, { useFetchArgsDefaults } from '../useFetchArgs'
-import { ReactElement, ReactNode } from 'react'
+import { ReactNode } from 'react'
 import { Provider } from '..'
 import React from 'react'
 import { isServer } from '../utils'
@@ -8,8 +8,8 @@ import { isServer } from '../utils'
 describe('useFetchArgs: general usages', (): void => {
   if (isServer) return
 
-  const wrapper = ({ children }: { children?: ReactNode }): ReactElement => (
-    <Provider url='https://example.com'>{children as ReactElement}</Provider>
+  const wrapper = ({ children }: { children?: ReactNode }): ReactNode => (
+    <Provider url='https://example.com'>{children}</Provider>
   )
 
   it('should create custom options with `onMount: false` by default', (): void => {
@@ -96,8 +96,8 @@ describe('useFetchArgs: general usages', (): void => {
   it('should have a default `url` if no URL is set in Provider', (): void => {
     if (isServer) return
 
-    const wrapper2 = ({ children }: { children?: ReactNode }): ReactElement => (
-      <Provider>{children as ReactElement}</Provider>
+    const wrapper2 = ({ children }: { children?: ReactNode }): ReactNode => (
+      <Provider>{children}</Provider>
     )
 
     const { result } = renderHook((): any => useFetchArgs(), { wrapper: wrapper2 })
@@ -124,8 +124,8 @@ describe('useFetchArgs: general usages', (): void => {
       }
     }
 
-    const wrapper2 = ({ children }: { children?: ReactNode }): ReactElement => (
-      <Provider url='https://example.com' options={{ interceptors }}>{children as ReactElement}</Provider>
+    const wrapper2 = ({ children }: { children?: ReactNode }): ReactNode => (
+      <Provider url='https://example.com' options={{ interceptors }}>{children}</Provider>
     )
 
     const { result } = renderHook(
@@ -191,8 +191,8 @@ describe('useFetchArgs: general usages', (): void => {
 
   it('should create custom options and use the global options instead of defaults', (): void => {
     const options = { headers: { 'Content-Type': 'application/text' } }
-    const wrapper = ({ children }: { children?: ReactNode }): ReactElement => (
-      <Provider options={options}>{children as ReactElement}</Provider>
+    const wrapper = ({ children }: { children?: ReactNode }): ReactNode => (
+      <Provider options={options}>{children}</Provider>
     )
     const { result } = renderHook((): any => useFetchArgs(), { wrapper })
     expect(result.current).toStrictEqual({
@@ -213,8 +213,8 @@ describe('useFetchArgs: general usages', (): void => {
         'Content-Type': 'application/text',
       },
     }
-    const wrapper = ({ children }: { children?: ReactNode }): ReactElement => (
-      <Provider options={options}>{children as ReactElement}</Provider>
+    const wrapper = ({ children }: { children?: ReactNode }): ReactNode => (
+      <Provider options={options}>{children}</Provider>
     )
     const overwriteProviderOptions = {
       headers: {

--- a/src/useFetch.ts
+++ b/src/useFetch.ts
@@ -45,7 +45,7 @@ function useFetch<TData = any>(...args: UseFetchArgs): UseFetch<TData> {
   const timedout = useRef(false)
   const attempts = useRef(retries)
 
-  const [loading, setLoading] = useState(defaults.loading)
+  const [loading, setLoading] = useState<boolean>(defaults.loading)
   const [error, setError] = useState<any>()
 
   const makeFetch = useCallback((method: HTTPMethod): FetchData => {
@@ -129,7 +129,7 @@ function useFetch<TData = any>(...args: UseFetchArgs): UseFetch<TData> {
     abort: () => controller.current && controller.current.abort(),
     query: (query, variables) => post({ query, variables }),
     mutate: (mutation, variables) => post({ mutation, variables }),
-    loading: loading as boolean,
+    loading: loading,
     error,
     data: data.current,
   }
@@ -154,7 +154,7 @@ function useFetch<TData = any>(...args: UseFetchArgs): UseFetch<TData> {
   useEffect(() => request.abort, [])
 
   return Object.assign<UseFetchArrayReturn<TData>, UseFetchObjectReturn<TData>>(
-    [request, makeResponseProxy(res), loading as boolean, error],
+    [request, makeResponseProxy(res), loading, error],
     { request, response: makeResponseProxy(res), ...request },
   )
 }


### PR DESCRIPTION
This pull request replaces all ReactElement typings with the more general ReactNode.
This means casting to ReactElement from ReactNode is not necessary anymore

This is not a breaking change, this just loosens the typings