### PR TITLE
added url and path to interceptor call

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,7 +484,9 @@ function App() {
   const options = {
     interceptors: {
       // every time we make an http request, this will run 1st before the request is made
-      request: async (options) => {
+      // url, path and route are supplied to the interceptor
+      // request options can be modified and must be returned
+      request: async (options, url, path, route) => {
         if (isExpired(token)) {
           token = await getNewToken()
           setToken(token)
@@ -681,7 +683,7 @@ const options = {
   
   // typically, `interceptors` would be added as an option to the `<Provider />`
   interceptors: {
-    request: async (options) => { // `async` is not required
+    request: async (options, url, path, route) => { // `async` is not required
       return options              // returning the `options` is important
     },
     response: (response) => {
@@ -717,7 +719,7 @@ Todos
  - [ ] maybe add translations [like this one](https://github.com/jamiebuilds/unstated-next)
  - [ ] add browser support to docs [1](https://github.com/godban/browsers-support-badges) [2](https://gist.github.com/danbovey/b468c2f810ae8efe09cb5a6fac3eaee5) (currently does not support ie 11)
  - [ ] maybe add contributors [all-contributors](https://github.com/all-contributors/all-contributors)
- - [ ] add sponsers [similar to this](https://github.com/carbon-app/carbon)
+ - [ ] add sponsors [similar to this](https://github.com/carbon-app/carbon)
  - [ ] tests
    - [ ] tests for SSR
    - [ ] tests for FormData (can also do it for react-native at same time. [see here](https://stackoverflow.com/questions/45842088/react-native-mocking-formdata-in-unit-tests))

--- a/docs/README.md
+++ b/docs/README.md
@@ -309,7 +309,9 @@ function App() {
   const options = {
     interceptors: {
       // every time we make an http request, this will run 1st before the request is made
-      request: async (options) => {
+      // url, path and route are supplied to the interceptor
+      // request options can be modified and must be returned
+      request: async (options, url, path, route) => {
         if (isExpired(token)) {
           token = await getNewToken()
           setToken(token)
@@ -640,7 +642,7 @@ const options = {
   
   // typically, `interceptors` would be added as an option to the `<Provider />`
   interceptors: {
-    request: async (options) => { // `async` is not required
+    request: async (options, url, path, route) => { // `async` is not required
       return options              // returning the `options` is important
     },
     response: (response) => {

--- a/src/__tests__/makeRouteAndOptions.test.tsx
+++ b/src/__tests__/makeRouteAndOptions.test.tsx
@@ -12,6 +12,8 @@ describe('makeRouteAndOptions: general usages', (): void => {
     const expectedRoute = '/test'
     const { route, options } = await makeRouteAndOptions(
       {},
+      '',
+      '',
       HTTPMethod.POST,
       controller,
       expectedRoute,
@@ -38,6 +40,8 @@ describe('makeRouteAndOptions: general usages', (): void => {
     }
     const { options } = await makeRouteAndOptions(
       {},
+      '',
+      '',
       HTTPMethod.POST,
       controller,
       '/test',
@@ -62,7 +66,7 @@ describe('makeRouteAndOptions: Errors', (): void => {
     const controller = new AbortController()
     // AKA, the last 2 arguments of makeRouteAndOptions are both objects
     try {
-      await makeRouteAndOptions({}, HTTPMethod.GET, controller, {}, {})
+      await makeRouteAndOptions({}, '', '', HTTPMethod.GET, controller, {}, {})
     } catch(err) {
       expect(err.name).toBe('Invariant Violation')
       expect(err.message).toBe('If first argument of get() is an object, you cannot have a 2nd argument. 😜')

--- a/src/makeRouteAndOptions.ts
+++ b/src/makeRouteAndOptions.ts
@@ -5,6 +5,8 @@ const { GET } = HTTPMethod
 
 export default async function makeRouteAndOptions(
   initialOptions: RequestInit,
+  url: string,
+  path: string,
   method: HTTPMethod,
   controller: AbortController,
   routeOrBody?: string | BodyInit | object,
@@ -62,6 +64,8 @@ export default async function makeRouteAndOptions(
   const options = await (async (): Promise<RequestInit> => {
     const opts = {
       ...initialOptions,
+      url,
+      path,
       method,
       signal: controller.signal,
     }
@@ -74,7 +78,7 @@ export default async function makeRouteAndOptions(
 
     if (body !== null) opts.body = body
 
-    if (requestInterceptor) return await requestInterceptor(opts)
+    if (requestInterceptor) return await requestInterceptor(opts, url, path)
     return opts
   })()
 

--- a/src/makeRouteAndOptions.ts
+++ b/src/makeRouteAndOptions.ts
@@ -64,8 +64,6 @@ export default async function makeRouteAndOptions(
   const options = await (async (): Promise<RequestInit> => {
     const opts = {
       ...initialOptions,
-      url,
-      path,
       method,
       signal: controller.signal,
     }

--- a/src/makeRouteAndOptions.ts
+++ b/src/makeRouteAndOptions.ts
@@ -76,7 +76,7 @@ export default async function makeRouteAndOptions(
 
     if (body !== null) opts.body = body
 
-    if (requestInterceptor) return await requestInterceptor(opts, url, path)
+    if (requestInterceptor) return await requestInterceptor(opts, url, path, route)
     return opts
   })()
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,7 +97,7 @@ export type UseFetch<TData> = UseFetchArrayReturn<TData> &
   UseFetchObjectReturn<TData>
 
 export type Interceptors = {
-  request?: (options: Options, url: string, path: string) => Promise<Options> | Options
+  request?: (options: Options, url: string, path: string, route: string) => Promise<Options> | Options
   response?: (response: Res<any>) => Res<any>
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,7 +97,7 @@ export type UseFetch<TData> = UseFetchArrayReturn<TData> &
   UseFetchObjectReturn<TData>
 
 export type Interceptors = {
-  request?: (options: Options) => Promise<Options> | Options
+  request?: (options: Options, url: string, path: string) => Promise<Options> | Options
   response?: (response: Res<any>) => Res<any>
 }
 

--- a/src/useFetch.ts
+++ b/src/useFetch.ts
@@ -64,6 +64,8 @@ function useFetch<TData = any>(...args: UseFetchArgs): UseFetch<TData> {
 
       let { route, options } = await makeRouteAndOptions(
         requestInit,
+        url,
+        path,
         method,
         theController,
         routeOrBody,


### PR DESCRIPTION
This allows interceptors to make decisions based on the url and path, for example add an token to the header of specific routes but not to all.