### PR TITLE
Add context.options dependency

### DIFF
--- a/src/useFetchArgs.ts
+++ b/src/useFetchArgs.ts
@@ -60,7 +60,7 @@ export default function useFetchArgs(
     if (!overwriteGlobalOptions) return context.options
     // make a copy so we make sure not to modify the original context
     return overwriteGlobalOptions({ ...context.options } as Options)
-  }, [])
+  }, [context.options])
 
   const urlOrOptions = urlOrOptionsOrOverwriteGlobal as string | OptionsMaybeURL
   const optionsNoURLs = optionsNoURLsOrOverwriteGlobalOrDeps as NoUrlOptions


### PR DESCRIPTION
Changed options, for example new Interceptor when token was changed, were not reflected in the next interceptor call.

part of the code:
```
const options: Options = useMemo(() => ({
  interceptors: {
    request: async (options) => {
      if (token) {
        (options.headers as any).Authorization = `Bearer ${token}`;
      }

      return options;
    },
  }
}), [token]);

return (
  <Provider url={config.API_URL} options={options}>
    {children}
  </Provider>
);
```

Adding context.options dependency to useMemo in useFetchArgs solved this issue.