### PR TITLE
fix: enable support for accepting an array for request body

### DIFF
--- a/src/__tests__/makeRouteAndOptions.test.tsx
+++ b/src/__tests__/makeRouteAndOptions.test.tsx
@@ -30,6 +30,27 @@ describe('makeRouteAndOptions: general usages', (): void => {
     })
   })
 
+  it('should accept an array for the body of a request',  async (): Promise<void> => {
+    const controller = new AbortController()
+    const { options } = await makeRouteAndOptions(
+      {},
+      '',
+      '',
+      HTTPMethod.POST,
+      controller,
+      '/test',
+      [],
+    )
+    expect(options).toStrictEqual({
+      body: '[]',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      method: 'POST',
+      signal: controller.signal,
+    })
+  })
+
   it('should correctly modify the options with the request interceptor', async (): Promise<void> => {
     const controller = new AbortController()
     const interceptors = {
@@ -72,6 +93,18 @@ describe('makeRouteAndOptions: Errors', (): void => {
       expect(err.message).toBe('If first argument of get() is an object, you cannot have a 2nd argument. 😜')
     }
   })
+
+  it('should error if 1st and 2nd arg of doFetch are both arrays', async (): Promise<void> => {
+    const controller = new AbortController()
+    // AKA, the last 2 arguments of makeRouteAndOptions are both arrays
+    try {
+      await makeRouteAndOptions({}, '', '', HTTPMethod.GET, controller, [], [])
+    } catch(err) {
+      expect(err.name).toBe('Invariant Violation')
+      expect(err.message).toBe('If first argument of get() is an object, you cannot have a 2nd argument. 😜')
+    }
+  })
+
   // ADD TESTS:
   // - request.get('/test', {})
   // - request.get('/test', '')

--- a/src/makeRouteAndOptions.ts
+++ b/src/makeRouteAndOptions.ts
@@ -1,5 +1,5 @@
 import { HTTPMethod, Interceptors, ValueOf, RouteAndOptions } from './types'
-import { isObject, invariant, isBrowser, isString } from './utils'
+import { invariant, isBrowser, isString, isBodyObject } from './utils'
 
 const { GET } = HTTPMethod
 
@@ -14,11 +14,11 @@ export default async function makeRouteAndOptions(
   requestInterceptor?: ValueOf<Pick<Interceptors, 'request'>>
 ): Promise<RouteAndOptions> {
   invariant(
-    !(isObject(routeOrBody) && isObject(bodyAs2ndParam)),
+    !(isBodyObject(routeOrBody) && isBodyObject(bodyAs2ndParam)),
     `If first argument of ${method.toLowerCase()}() is an object, you cannot have a 2nd argument. 😜`,
   )
   invariant(
-    !(method === GET && isObject(routeOrBody)),
+    !(method === GET && isBodyObject(routeOrBody)),
     `You can only have query params as 1st argument of request.get()`,
   )
   invariant(
@@ -33,15 +33,15 @@ export default async function makeRouteAndOptions(
   })()
 
   const body = ((): BodyInit | null => {
-    if (isObject(routeOrBody)) return JSON.stringify(routeOrBody)
-    if (isObject(bodyAs2ndParam)) return JSON.stringify(bodyAs2ndParam)
+    if (isBodyObject(routeOrBody)) return JSON.stringify(routeOrBody)
+    if (isBodyObject(bodyAs2ndParam)) return JSON.stringify(bodyAs2ndParam)
     if (
       isBrowser &&
       ((bodyAs2ndParam as any) instanceof FormData ||
         (bodyAs2ndParam as any) instanceof URLSearchParams)
     )
       return bodyAs2ndParam as string
-    if (isObject(initialOptions.body)) return JSON.stringify(initialOptions.body)
+    if (isBodyObject(initialOptions.body)) return JSON.stringify(initialOptions.body)
     return null
   })()
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -74,6 +74,13 @@ export const isString = (x: any): x is string => typeof x === 'string' // eslint
  */
 export const isObject = (obj: any): obj is object => Object.prototype.toString.call(obj) === '[object Object]' // eslint-disable-line
 
+/**
+ * Determines if the given param is an object that can be used as a request body.
+ * Returns true for native objects or arrays.
+ * @param obj 
+ */
+export const isBodyObject = (obj: any): boolean => isObject(obj) || Array.isArray(obj)
+
 export const isFunction = (v: any): boolean => typeof v === 'function'
 
 // TODO: come back and fix the "anys" in this http://bit.ly/2Lm3OLi


### PR DESCRIPTION
`useFetch` (and derived methods) did not allow an array to be used in a request. When attempting to send an array as a request body, it would always be sent as a null body in the request.

I recognize that this is a potential duplicate of #163 (Sorry @dzyko !). It is not my intention to step on anybody's toes, but that solution didn't address all of our use-cases. I would have had added to the conversation on that pull request, but it is time-sensitive for me to implement this fix, or I would have to abandon this library (we will be temporarily referencing a private mirror of the project until this PR is merged and officially released).

A couple of implementation notes:

* I added a utility method `isBodyObject` to check if the parameter is a body or a route
* I updated unit tests that appeared to be related to my change, and added another one to keep the unit tests robust
* I chose to use Array.isArray()
  * This method has excellent [browser support](https://caniuse.com/#search=isArray)
  * Performs very well in [benchmark tests](https://www.measurethat.net/Benchmarks/Show/6920/0/isarray-vs-instanceof-vs-symboliterator-vs-objectprotot#latest_results_block)

On a side note, when I ran the linter, there were a large number of formatting errors reported. Since these spanned many files that I didn't touch, I decided to manually do my best to follow the coding conventions in the existing files, and leave everything else as-is.