### PR TITLE
Check cache expiration correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -776,6 +776,7 @@ Todos
 - [ ] maybe add contributors [all-contributors](https://github.com/all-contributors/all-contributors)
 - [ ] add sponsors [similar to this](https://github.com/carbon-app/carbon)
 - [ ] tests
+  - [ ] doFetchArgs tests for `response.isExpired`
   - [ ] tests for SSR
   - [ ] tests for FormData (can also do it for react-native at same time. [see here](https://stackoverflow.com/questions/45842088/react-native-mocking-formdata-in-unit-tests))
   - [ ] tests for GraphQL hooks `useMutation` + `useQuery`

--- a/src/__tests__/doFetchArgs.test.tsx
+++ b/src/__tests__/doFetchArgs.test.tsx
@@ -1,7 +1,6 @@
 import doFetchArgs from '../doFetchArgs'
-import { HTTPMethod, CachePolicies } from '../types'
-
-const defaultCachePolicy = CachePolicies.CACHE_FIRST
+import { HTTPMethod } from '../types'
+import { defaults } from '../useFetchArgs'
 
 describe('doFetchArgs: general usages', (): void => {
   it('should be defined', (): void => {
@@ -18,7 +17,8 @@ describe('doFetchArgs: general usages', (): void => {
       '',
       HTTPMethod.POST,
       controller,
-      defaultCachePolicy,
+      defaults.cachePolicy,
+      defaults.cacheLife,
       cache,
       expectedRoute,
       {}
@@ -43,7 +43,8 @@ describe('doFetchArgs: general usages', (): void => {
       '',
       HTTPMethod.POST,
       controller,
-      defaultCachePolicy,
+      defaults.cachePolicy,
+      defaults.cacheLife,
       cache,
       '/test',
       []
@@ -68,7 +69,8 @@ describe('doFetchArgs: general usages', (): void => {
       '/path',
       HTTPMethod.POST,
       controller,
-      defaultCachePolicy,
+      defaults.cachePolicy,
+      defaults.cacheLife,
       cache,
       '/route',
       {}
@@ -91,7 +93,8 @@ describe('doFetchArgs: general usages', (): void => {
       '',
       HTTPMethod.POST,
       controller,
-      defaultCachePolicy,
+      defaults.cachePolicy,
+      defaults.cacheLife,
       cache,
       '/test',
       {},
@@ -138,7 +141,8 @@ describe('doFetchArgs: Errors', (): void => {
         '',
         HTTPMethod.GET,
         controller,
-        defaultCachePolicy,
+        defaults.cachePolicy,
+        defaults.cacheLife,
         cache,
         {},
         {}
@@ -176,7 +180,8 @@ describe('doFetchArgs: Errors', (): void => {
         '',
         HTTPMethod.GET,
         controller,
-        defaultCachePolicy,
+        defaults.cachePolicy,
+        defaults.cacheLife,
         cache,
         [],
         []

--- a/src/__tests__/useFetch.test.tsx
+++ b/src/__tests__/useFetch.test.tsx
@@ -406,17 +406,17 @@ describe('caching - useFetch - BROWSER', (): void => {
   })
 
   it('should make a second request if cacheLife has exprired. `cache-first` cachePolicy', async (): Promise<void> => {
-    // TODO: this test is extra brittle. I've tried many things.
-    // if it fails, try restarting your tests entirely.
     // run the request on mount
     const { result, waitForNextUpdate } = renderHook(() => useFetch('https://example.com', {
-      cacheLife: 0.01
+      cacheLife: 1
     }, []))
     expect(result.current.loading).toBe(true)
     await waitForNextUpdate()
     expect(result.current.loading).toBe(false)
     expect(result.current.data).toEqual(expected)
     expect(fetch.mock.calls.length).toEqual(1)
+    // wait ~20ms to allow cache to expire
+    await new Promise(resolve => setTimeout(resolve, 20))
     // make a 2nd request
     await act(async () => {
       await result.current.get()

--- a/src/doFetchArgs.ts
+++ b/src/doFetchArgs.ts
@@ -105,7 +105,7 @@ export default async function doFetchArgs<TData = any>(
       isExpired: cacheLife > 0 && responseAge > cacheLife,
       id: responseID,
       cached: cache.get(responseID) as Response | undefined,
-      ageID: responseAgeID,
+      ageID: responseAgeID
     }
   }
 }

--- a/src/doFetchArgs.ts
+++ b/src/doFetchArgs.ts
@@ -10,6 +10,7 @@ export default async function doFetchArgs<TData = any>(
   method: HTTPMethod,
   controller: AbortController,
   cachePolicy: CachePolicies,
+  cacheLife: number,
   cache: Map<string, Res<TData> | number>,
   routeOrBody?: string | BodyInit | object,
   bodyAs2ndParam?: BodyInit | object,
@@ -94,15 +95,17 @@ export default async function doFetchArgs<TData = any>(
     .map(([key, value]) => `${key}:${value}`).join('||')
   const responseAgeID = `${responseID}:ts`
 
+  const responseAge = Date.now() - ((cache.get(responseAgeID) || 0) as number)
+
   return {
     url,
     options,
     response: {
       isCached: cache.has(responseID),
+      isExpired: cacheLife > 0 && responseAge > cacheLife,
       id: responseID,
       cached: cache.get(responseID) as Response | undefined,
       ageID: responseAgeID,
-      age: (cache.get(responseAgeID) || 0) as number
     }
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,10 +67,10 @@ export interface DoFetchArgs {
   options: RequestInit
   response: {
     isCached: boolean
+    isExpired: boolean
     id: string
     cached?: Response
     ageID: string
-    age: number
   }
 }
 

--- a/src/useFetch.ts
+++ b/src/useFetch.ts
@@ -67,6 +67,7 @@ function useFetch<TData = any>(...args: UseFetchArgs): UseFetch<TData> {
         method,
         theController,
         cachePolicy,
+        cacheLife,
         cache,
         routeOrBody,
         body,
@@ -75,7 +76,7 @@ function useFetch<TData = any>(...args: UseFetchArgs): UseFetch<TData> {
 
       if (response.isCached && cachePolicy === CACHE_FIRST) {
         setLoading(true)
-        if (cacheLife > 0 && Date.now() - response.age > cacheLife) {
+        if (response.isExpired) {
           cache.delete(response.id)
           cache.delete(response.ageID)
         } else {

--- a/src/useFetch.ts
+++ b/src/useFetch.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, useRef, useMemo } from 'react'
+import { useEffect, useState, useCallback, useRef } from 'react'
 import { FunctionKeys, NonFunctionKeys } from 'utility-types'
 import useSSR from 'use-ssr'
 import {
@@ -162,26 +162,24 @@ function useFetch<TData = any>(...args: UseFetchArgs): UseFetch<TData> {
     data: data.current
   }
 
-  const response = useMemo((): any => {
-    const clonedResponse = ('clone' in res.current ? res.current.clone() : {}) as Res<TData>
-    return Object.defineProperties({}, responseKeys.reduce((acc: any, field: keyof Res<TData>) => {
-      if (responseFields.includes(field as any)) {
-        acc[field] = {
-          get: () => {
-            if (field === 'data') return data.current
-            return clonedResponse[field as (NonFunctionKeys<Res<any>> | 'data')]
-          },
-          enumerable: true
-        }
-      } else if (responseMethods.includes(field as any)) {
-        acc[field] = {
-          value: () => clonedResponse[field as Exclude<FunctionKeys<Res<any>>, 'data'>](),
-          enumerable: true
-        }
+  const clonedResponse = ('clone' in res.current ? res.current.clone() : {}) as Res<TData>
+  const response = Object.defineProperties({}, responseKeys.reduce((acc: any, field: keyof Res<TData>) => {
+    if (responseFields.includes(field as any)) {
+      acc[field] = {
+        get: () => {
+          if (field === 'data') return data.current
+          return clonedResponse[field as (NonFunctionKeys<Res<any>> | 'data')]
+        },
+        enumerable: true
       }
-      return acc
-    }, {}))
-  }, [res.current])
+    } else if (responseMethods.includes(field as any)) {
+      acc[field] = {
+        value: () => clonedResponse[field as Exclude<FunctionKeys<Res<any>>, 'data'>](),
+        enumerable: true
+      }
+    }
+    return acc
+  }, {}))
 
   // onMount/onUpdate
   useEffect((): any => {

--- a/src/useFetch.ts
+++ b/src/useFetch.ts
@@ -75,7 +75,7 @@ function useFetch<TData = any>(...args: UseFetchArgs): UseFetch<TData> {
 
       if (response.isCached && cachePolicy === CACHE_FIRST) {
         setLoading(true)
-        if (cacheLife > 0 && response.age > cacheLife) {
+        if (cacheLife > 0 && Date.now() - response.age > cacheLife) {
           cache.delete(response.id)
           cache.delete(response.ageID)
         } else {

--- a/src/useFetchArgs.ts
+++ b/src/useFetchArgs.ts
@@ -48,7 +48,7 @@ export const useFetchArgsDefaults = {
 }
 
 // TODO: see if `Object.entries` is supported for IE
-const defaults = Object.entries(useFetchArgsDefaults).reduce((acc, [key, value]) => {
+export const defaults = Object.entries(useFetchArgsDefaults).reduce((acc, [key, value]) => {
   if (isObject(value)) return { ...acc, ...value }
   return { ...acc, [key]: value }
 }, {} as Flatten<UseFetchArgsReturn>)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -173,7 +173,7 @@ export const responseMethods: ResponseMethods[] = ['clone', 'arrayBuffer', 'blob
 // const responseFields = [...Object.getOwnPropertyNames(Object.getPrototypeOf(new Response())), 'data'].filter(p => p !== 'constructor')
 type ResponseKeys = (keyof Res<any>)
 export const responseKeys: ResponseKeys[] = [...responseFields, ...responseMethods]
-export const emptyCustomResponse = Object.defineProperties({}, responseKeys.reduce((acc: any, field: ResponseKeys ) => {
+export const emptyCustomResponse = Object.defineProperties({}, responseKeys.reduce((acc: any, field: ResponseKeys) => {
   if (responseFields.includes(field as any)) {
     acc[field] = {
       get: () => { /* undefined */ },


### PR DESCRIPTION
`response.age` gets set to a `Date.now()` timestamp, and thus needs to be subtracted from it before comparison with `cacheLife`.

Also updated the cache expiration test so that it:
- Passes an integer as `cacheLife` since it's specified in milliseconds
- Waits a while to allow the cache TTL to pass