### PR TITLE
Only reset abortcontroller ref if captured instance is same as ref

### DIFF
--- a/src/useFetch.ts
+++ b/src/useFetch.ts
@@ -158,7 +158,7 @@ function useFetch<TData = any>(...args: UseFetchArgs): UseFetch<TData> {
       } finally {
         timedout.current = false
         if (timer) clearTimeout(timer)
-        controller.current = undefined
+        if (controller.current === theController) controller.current = undefined
       }
 
       if (newRes && !newRes.ok && !error.current) error.current = makeError(newRes.status, newRes.statusText)


### PR DESCRIPTION
[#302](https://github.com/ava/use-http/issues/302) describes a race condition where an aborted request resets the abort controller ref even though a subsequent request has been issued and already replaced the ref.

Code sandbox: https://codesandbox.io/p/sandbox/react-hooks-usefetch-forked-xsdrhl?file=%2Fsrc%2Findex.js

Steps to reproduce:
1. Open sand box
2. View browser network traffic (ctrl + i / Option + ⌘ + I / select network)
3. Repeatedly click "Click Me" before previous request has completed
4. Note that approximately every second request is aborted while the others complete

Cause:
On completing a request (normal or aborted), the captured AbortController ref (controller.current) is set to undefined in the finally block. If a request is aborted and then immediately resubmitted, this results in a race condition where:

1. Request A is started
2.  AbortController for request A is captured
5. Request A abort is initiated via abort()
6. Abort signal is sent
7. Request B is started
8. AbortController for request B is captured
9. Request A completes and sets captured controller ref to undefined
10. Request B abort is initiated via abort()
11. Abort signal has been lost by 8 and cannot be issued
12. Request B completes

Resolution:
Only set the controller ref to undefined if the ref is still set to the current controller instance

Note:
This PR makes no attempt to resolve the underlying race condition. It proposes a solution to allow for the last issued request to be aborted while potentially managing the race condition through other means.