### PR TITLE
Ensure useFetch suspends when triggering a service call more than once

### DIFF
--- a/src/useFetch.ts
+++ b/src/useFetch.ts
@@ -182,6 +182,7 @@ function useFetch<TData = any>(...args: UseFetchArgs): UseFetch<TData> {
 
     if (suspense) {
       return async (...args) => {
+        suspenseStatus.current = 'pending'
         suspender.current = doFetch(...args).then(
           (newData) => {
             suspenseStatus.current = 'success'


### PR DESCRIPTION
useFetch experimental support for React Suspense works great when the call made is only used once. In the event of an application successfully suspending after a service call, and then triggering that same call again, the suspense mechanism does not suspend as expected. This is because the suspenseStatus ref used to keep track of the suspense status is never reset! This change makes it so that when the suspense promise is created, the suspenseStatus ref is reset so that the promise can be successfully thrown for React to catch.